### PR TITLE
更新添加mac系统选择，支持多平台路径配置（Win/macOS/Linux）

### DIFF
--- a/src/main/config/config.js
+++ b/src/main/config/config.js
@@ -2,24 +2,24 @@ import path from 'path'
 import os from 'os'
 
 const isDev = process.env.NODE_ENV === 'development'
-const isWin = process.platform === 'win32'
+const platform = process.platform // 'win32' | 'linux' | 'darwin'
 
 export const serviceUrl = {
   face2face: isDev ? 'http://192.168.4.204:8383/easy' : 'http://127.0.0.1:8383/easy',
   tts: isDev ? 'http://192.168.4.204:18180' : 'http://127.0.0.1:18180'
 }
 
+// 根据操作系统选择不同的路径
+const getBasePath = () => {
+  if (platform === 'win32') return path.join('D:', 'heygem_data')
+  return path.join(os.homedir(), 'heygem_data')
+}
+
+const basePath = getBasePath()
+
 export const assetPath = {
-  model: isWin
-    ? path.join('D:', 'heygem_data', 'face2face', 'temp')
-    : path.join(os.homedir(), 'heygem_data', 'face2face', 'temp'), // 模特视频
-  ttsProduct: isWin
-    ? path.join('D:', 'heygem_data', 'face2face', 'temp')
-    : path.join(os.homedir(), 'heygem_data', 'face2face', 'temp'), // TTS 产物
-  ttsRoot: isWin
-    ? path.join('D:', 'heygem_data', 'voice', 'data')
-    : path.join(os.homedir(), 'heygem_data', 'voice', 'data'), // TTS服务根目录
-  ttsTrain: isWin
-    ? path.join('D:', 'heygem_data', 'voice', 'data', 'origin_audio')
-    : path.join(os.homedir(), 'heygem_data', 'voice', 'data', 'origin_audio') // TTS 训练产物
+  model: path.join(basePath, 'face2face', 'temp'),       // 模特视频路径
+  ttsProduct: path.join(basePath, 'face2face', 'temp'),  // TTS 产物路径
+  ttsRoot: path.join(basePath, 'voice', 'data'),         // TTS 根目录
+  ttsTrain: path.join(basePath, 'voice', 'data', 'origin_audio') // TTS 训练数据
 }

--- a/src/main/util/ffmpeg.js
+++ b/src/main/util/ffmpeg.js
@@ -3,9 +3,17 @@ import path from 'path'
 import log from '../logger.js'
 
 function initFFmpeg() {
+  if (!process.env.NODE_ENV) {
+    process.env.NODE_ENV = 'production'
+  }
+
+  const key = `${process.env.NODE_ENV}-${process.platform}`
+
   const ffmpegPath = {
     'development-win32': path.join(__dirname, '../../resources/ffmpeg/win-amd64/bin/ffmpeg.exe'),
     'development-linux': path.join(__dirname, '../../resources/ffmpeg/linux-amd64/ffmpeg'),
+    'development-darwin': path.join(__dirname, '../../resources/ffmpeg/mac-x64/ffmpeg'),
+
     'production-win32': path.join(
       process.resourcesPath,
       'app.asar.unpacked',
@@ -22,21 +30,22 @@ function initFFmpeg() {
       'ffmpeg',
       'linux-amd64',
       'ffmpeg'
+    ),
+    'production-darwin': path.join(
+      process.resourcesPath,
+      'app.asar.unpacked',
+      'resources',
+      'ffmpeg',
+      'mac-x64',
+      'ffmpeg'
     )
   }
-
-  if(process.env.NODE_ENV === undefined){
-    process.env.NODE_ENV = 'production'
-  }
-
-  const ffmpegPathValue = ffmpegPath[`${process.env.NODE_ENV}-${process.platform}`]
-  log.debug('ENV:', `${process.env.NODE_ENV}-${process.platform}`)
-  log.info('FFmpeg path:', ffmpegPathValue)
-  ffmpeg.setFfmpegPath(ffmpegPathValue)
 
   const ffprobePath = {
     'development-win32': path.join(__dirname, '../../resources/ffmpeg/win-amd64/bin/ffprobe.exe'),
     'development-linux': path.join(__dirname, '../../resources/ffmpeg/linux-amd64/ffprobe'),
+    'development-darwin': path.join(__dirname, '../../resources/ffmpeg/mac-x64/ffprobe'),
+
     'production-win32': path.join(
       process.resourcesPath,
       'app.asar.unpacked',
@@ -53,10 +62,24 @@ function initFFmpeg() {
       'ffmpeg',
       'linux-amd64',
       'ffprobe'
+    ),
+    'production-darwin': path.join(
+      process.resourcesPath,
+      'app.asar.unpacked',
+      'resources',
+      'ffmpeg',
+      'mac-x64',
+      'ffprobe'
     )
   }
 
-  const ffprobePathValue = ffprobePath[`${process.env.NODE_ENV}-${process.platform}`]
+  const ffmpegPathValue = ffmpegPath[key]
+  const ffprobePathValue = ffprobePath[key]
+
+  log.debug('ENV:', key)
+  log.info('FFmpeg path:', ffmpegPathValue)
+  ffmpeg.setFfmpegPath(ffmpegPathValue)
+
   log.info('FFprobe path:', ffprobePathValue)
   ffmpeg.setFfprobePath(ffprobePathValue)
 }
@@ -69,10 +92,11 @@ export function extractAudio(videoPath, audioPath) {
       .noVideo()
       .save(audioPath)
       .on('end', () => {
-        log.info('audio split done')
+        log.info('Audio extraction completed.')
         resolve(true)
       })
       .on('error', (err) => {
+        log.error('Audio extraction failed:', err)
         reject(err)
       })
   })
@@ -82,13 +106,13 @@ export function getVideoDuration(videoPath) {
   return new Promise((resolve, reject) => {
     ffmpeg(videoPath).ffprobe((err, data) => {
       if (err) {
-        log.error("🚀 ~ ffmpeg ~ err:", err)
+        log.error('FFprobe error:', err)
         reject(err)
-      } else if (data && data.streams && data.streams.length > 0) {
+      } else if (data?.streams?.length > 0) {
         resolve(data.streams[0].duration) // 单位秒
       } else {
-        log.error('No streams found')
-        reject(new Error('No streams found'))
+        log.error('No video streams found.')
+        reject(new Error('No video streams found.'))
       }
     })
   })


### PR DESCRIPTION
更新添加mac系统

本次提交对资源路径管理逻辑进行了优化，新增对 macOS（darwin）系统的支持，并统一了各平台的路径配置方式，提升了代码可读性和可维护性。

🔧 修改内容：
增加对 macOS 系统的路径支持，基于 os.homedir() 自动定位用户目录。

用 getBasePath() 工具函数统一判断系统平台，减少重复逻辑。

保持 Windows 和 Linux 下的行为不变，路径结构一致。

serviceUrl 配置保持不变，仅优化资源路径管理部分。

📁 涉及路径字段如下：
model：face2face 模特视频缓存路径

ttsProduct：TTS 推理产物输出路径

ttsRoot：TTS 数据根目录

ttsTrain：TTS 原始音频训练数据路径

已在 Win、Linux、macOS 上验证路径解析逻辑均正常。

如需补充自动创建文件夹逻辑（如 fs.mkdirSync），可在下一步支持。欢迎合并～