### PR TITLE
Update docker-compose-linux.yml

### DIFF
--- a/deploy/docker-compose-linux.yml
+++ b/deploy/docker-compose-linux.yml
@@ -47,11 +47,6 @@ services:
       - ~/heygem_data/face2face:/code/data
     environment:
       - PYTORCH_CUDA_ALLOC_CONF=max_split_size_mb:512
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - capabilities: [gpu]
     shm_size: '8g'
     ports:
       - '8383:8383'


### PR DESCRIPTION
For the heygem-gen-video service, you have both runtime: `nvidia` and the newer `deploy: resources:` syntax for GPU access. This mixing of old and new syntax could be causing conflicts.

Additionally, your GPU configuration for heygem-gen-video is incomplete compared to the other services.

Before this change:
```
heygem-gen-video  | [2025-04-08 02:44:19] [app_local.py[line:231]] [INFO] [TransDhTask init]
heygem-gen-video  | Traceback (most recent call last):
heygem-gen-video  |   File "/code/app_local.py", line 231, in <module>
heygem-gen-video  |     TransDhTask.instance()
heygem-gen-video  |   File "trans_dh_service.py", line 1207, in trans_dh_service.TransDhTask.instance
heygem-gen-video  |   File "trans_dh_service.py", line 1189, in trans_dh_service.TransDhTask.__init__
heygem-gen-video  |   File "compute_ctc_att_bnf.py", line 130, in compute_ctc_att_bnf.load_ppg_model
heygem-gen-video  |   File "/usr/local/python3/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1152, in to
heygem-gen-video  |     return self._apply(convert)
heygem-gen-video  |   File "/usr/local/python3/lib/python3.8/site-packages/torch/nn/modules/module.py", line 802, in _apply
heygem-gen-video  |     module._apply(fn)
heygem-gen-video  |   File "/usr/local/python3/lib/python3.8/site-packages/torch/nn/modules/module.py", line 802, in _apply
heygem-gen-video  |     module._apply(fn)
heygem-gen-video  |   File "/usr/local/python3/lib/python3.8/site-packages/torch/nn/modules/module.py", line 802, in _apply
heygem-gen-video  |     module._apply(fn)
heygem-gen-video  |   [Previous line repeated 1 more time]
heygem-gen-video  |   File "/usr/local/python3/lib/python3.8/site-packages/torch/nn/modules/module.py", line 825, in _apply
heygem-gen-video  |     param_applied = fn(param)
heygem-gen-video  |   File "/usr/local/python3/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1150, in convert
heygem-gen-video  |     return t.to(device, dtype if t.is_floating_point() or t.is_complex() else None, non_blocking)
heygem-gen-video  |   File "/usr/local/python3/lib/python3.8/site-packages/torch/cuda/__init__.py", line 302, in _lazy_init
heygem-gen-video  |     torch._C._cuda_init()
heygem-gen-video  | RuntimeError: Found no NVIDIA driver on your system. Please check that you have an NVIDIA GPU and installed a driver from http://www.nvidia.com/Download/index.aspx
```

After this change, the error was goine.