### PR TITLE
fix: propagate voice training failures

### DIFF
--- a/src/main/service/voice.js
+++ b/src/main/service/voice.js
@@ -23,7 +23,7 @@ export async function train(path, lang = 'zh') {
   })
   log.debug('~ train ~ res:', res)
   if (res.code !== 0) {
-    return false
+    throw new Error(res.msg || `Voice training failed (code ${res.code})`)
   } else {
     const { asr_format_audio_url, reference_audio_text } = res
     return insert({ origin_audio_path: path, lang, asr_format_audio_url, reference_audio_text })

--- a/src/main/service/voice.test.js
+++ b/src/main/service/voice.test.js
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict'
+import { mock, test } from 'node:test'
+
+const insertVoice = mock.fn()
+const preprocessAndTrain = mock.fn(async () => ({
+  code: -1,
+  msg: 'ASR service is unavailable'
+}))
+
+mock.module(new URL('../dao/voice.js', import.meta.url), {
+  namedExports: {
+    insert: insertVoice,
+    selectAll: mock.fn(),
+    selectByID: mock.fn()
+  }
+})
+mock.module(new URL('../api/tts.js', import.meta.url), {
+  namedExports: {
+    makeAudio: mock.fn(),
+    preprocessAndTran: preprocessAndTrain
+  }
+})
+mock.module(new URL('../config/config.js', import.meta.url), {
+  namedExports: {
+    assetPath: {}
+  }
+})
+mock.module(new URL('../logger.js', import.meta.url), {
+  defaultExport: {
+    debug: mock.fn(),
+    error: mock.fn()
+  }
+})
+mock.module('electron', {
+  namedExports: {
+    ipcMain: { handle: mock.fn() }
+  }
+})
+mock.module('dayjs', {
+  defaultExport: mock.fn()
+})
+
+const { train } = await import('./voice.js')
+
+test('train propagates the backend error without inserting a voice record', async () => {
+  await assert.rejects(train('origin_audio/test.wav', 'zh'), /ASR service is unavailable/)
+  assert.equal(insertVoice.mock.callCount(), 0)
+})


### PR DESCRIPTION
## Summary

- propagate the TTS/ASR backend message when voice training fails
- stop before inserting a model whose `voice_id` would be the boolean `false`
- add a regression test for the failure path

## Root cause

`voice.train()` returned `false` for every non-zero backend response. `model.addModel()` then passed that value to the SQLite `voice_id` column, replacing the actionable training error with a secondary binding error.

The failure now rejects with the backend's message, which the existing model-creation UI already catches and displays.

This complements the Windows Docker troubleshooting documentation in #620: that PR helps repair the service connection, while this change preserves the original backend error when training still fails.

Closes #619.

## Verification

```text
node --no-warnings --experimental-test-module-mocks --test src/main/service/voice.test.js
tests 1, pass 1, fail 0
```

The regression failed before the implementation with `Missing expected rejection`. `node --check` passes for both changed JavaScript files, and `git diff --check` is clean.
